### PR TITLE
DB-10768 Make Input Schema Configurable

### DIFF
--- a/spark2.4/build.sbt
+++ b/spark2.4/build.sbt
@@ -7,7 +7,7 @@ scalaVersion := "2.11.12"
 
 //val spliceVersion = "2.8.0.1945"
 //val spliceVersion = "3.1.0.1967-SNAPSHOT"
-val spliceVersion = "3.2.0.1980-SNAPSHOT"
+val spliceVersion = "3.2.0.1985-SNAPSHOT"
 
 // https://github.com/sbt/sbt/issues/5046
 ThisBuild / useCoursier := false

--- a/spark2.4/build.sbt
+++ b/spark2.4/build.sbt
@@ -5,8 +5,6 @@ version := "0.3.0-SNAPSHOT"
 scalaVersion := "2.11.12"
 //scalaVersion := "2.11.6"
 
-//val spliceVersion = "2.8.0.1945"
-//val spliceVersion = "3.1.0.1967-SNAPSHOT"
 val spliceVersion = "3.2.0.1985-SNAPSHOT"
 
 // https://github.com/sbt/sbt/issues/5046

--- a/spark2.4/src/main/scala/Inserter.scala
+++ b/spark2.4/src/main/scala/Inserter.scala
@@ -16,6 +16,7 @@ class Inserter(
     spliceUrl: String, 
     spliceKafkaServers: String, 
     spliceKafkaPartitions: String,
+    useFlowMarkers: Boolean,
     spliceTable: String, 
     dfSchema: StructType,
     taskQueue: BlockingQueue[(Seq[RowForKafka], Long, String)],
@@ -28,7 +29,7 @@ class Inserter(
     "url" -> spliceUrl,
     "KAFKA_SERVERS" -> spliceKafkaServers,
     "KAFKA_TOPIC_PARTITIONS" -> spliceKafkaPartitions,
-    "USE_FLOW_MARKERS" -> "true"
+    "USE_FLOW_MARKERS" -> useFlowMarkers.toString
   ))
   
   nsds.setTable(spliceTable, dfSchema)

--- a/spark2.4/src/main/scala/KafkaReader.scala
+++ b/spark2.4/src/main/scala/KafkaReader.scala
@@ -24,16 +24,18 @@ object KafkaReader {
     val appName = args(0)
     val externalKafkaServers = args(1)
     val externalTopic = args(2)
-    val spliceUrl = args(3)
-    val spliceTable = args(4)
-    val spliceKafkaPartitions = args.slice(5,6).headOption.getOrElse("1")
+    val schemaDDL = args(3)
+    val spliceUrl = args(4)
+    val spliceTable = args(5)
     val spliceKafkaServers = args.slice(6,7).headOption.getOrElse("localhost:9092")
+    val spliceKafkaPartitions = args.slice(7,8).headOption.getOrElse("1")
 //    val spliceKafkaTimeout = args.slice(7,8).headOption.getOrElse("20000")
-    val numLoaders = args.slice(7,8).headOption.getOrElse("1").toInt
-    val numInserters = args.slice(8,9).headOption.getOrElse("1").toInt
-    val maxPollRecs = args.slice(9,10).headOption
-    val groupId = args.slice(10,11).headOption.getOrElse("")
-    val clientId = args.slice(11,12).headOption.getOrElse("")
+    val numLoaders = args.slice(8,9).headOption.getOrElse("1").toInt
+    val numInserters = args.slice(9,10).headOption.getOrElse("1").toInt
+    val useFlowMarkers = args.slice(10,11).headOption.getOrElse("false").toBoolean
+    val maxPollRecs = args.slice(11,12).headOption
+    val groupId = args.slice(12,13).headOption.getOrElse("")
+    val clientId = args.slice(13,14).headOption.getOrElse("")
 
     val spark = SparkSession.builder.appName(appName).getOrCreate()
 
@@ -45,7 +47,16 @@ object KafkaReader {
 //
 //    val metricsProducer = new KafkaProducer[Integer, Long](props)
 //    val metricsTopic = "ssds-metrics"
+    
+    // Create schema from ddl string like
+    //    "ID STRING NOT NULL, LOCATION STRING, TEMPERATURE DOUBLE, HUMIDITY DOUBLE, TM TIMESTAMP"
+    var schema = new StructType
+    schemaDDL.split(",").foreach( s => {
+      val f = s.trim.split(" ")
+      schema = schema.add( f(0) , f(1) , ! s.toUpperCase.contains("NOT NULL") )
+    })
 
+    // Keep for reference -- Weather demo
     //    val schema = StructType(
 //      StructField("ID", StringType, false) ::
 //      StructField("LOCATION", StringType, true) ::
@@ -53,15 +64,16 @@ object KafkaReader {
 //      StructField("HUMIDITY", DoubleType, true) ::
 //      StructField("TM", TimestampType, true) :: Nil)
 
-    val schema = StructType(
-      StructField("ID", LongType, false) ::
-      StructField("PAYLOAD", StringType, true) ::
-      StructField("SRC_SERVER", StringType, false) ::
-      StructField("SRC_THREAD", LongType, true) ::
-      StructField("TM_GENERATED", LongType, false) :: Nil)
-//      StructField("PTN_NSDS", IntegerType, true) ::
-//      StructField("TM_NSDS", LongType, true) :: Nil)
-//      StructField("TM_EXT_KAFKA", LongType, true) :: Nil)
+    // Keep for reference -- Performance test (first five fields)
+//    val schema = StructType(
+//      StructField("ID", LongType, false) ::
+//      StructField("PAYLOAD", StringType, true) ::
+//      StructField("SRC_SERVER", StringType, false) ::
+//      StructField("SRC_THREAD", LongType, true) ::
+//      StructField("TM_GENERATED", LongType, false) :: Nil)
+////      StructField("PTN_NSDS", IntegerType, true) ::
+////      StructField("TM_NSDS", LongType, true) :: Nil)
+////      StructField("TM_EXT_KAFKA", LongType, true) :: Nil)
 
 //    val schema = new SplicemachineContext(spliceUrl, externalKafkaServers).getSchema(spliceTable)
 
@@ -90,7 +102,6 @@ object KafkaReader {
       .format("kafka")
       .option("subscribe", externalTopic)
       .option("kafka.bootstrap.servers", externalKafkaServers)
-//      .option("timestampFormat", "yyyy/MM/dd HH:mm:ss")
       //.option("minPartitions", minPartitions)  // probably better to rely on num partitions of the external topic
       .option("failOnDataLoss", "false")
 
@@ -102,11 +113,17 @@ object KafkaReader {
       reader.option("kafka.client.id", s"$group-$clientId")  // probably should use uuid instead of user input TODO
     }
     
-    val values = reader
-      .load.select(from_json(col("value") cast "string", schema, Map( "timestampFormat" -> "yyyy/MM/dd HH:mm:ss" )) as "data", col("timestamp") cast "long" as "TM_EXT_KAFKA")
-      .select("data.*", "TM_EXT_KAFKA")
-      .withColumn("TM_EXT_KAFKA", col("TM_EXT_KAFKA") * 1000)
-      .withColumn("TM_SSDS", unix_timestamp * 1000 )
+    val values = if( useFlowMarkers ) {
+      reader
+        .load.select(from_json(col("value") cast "string", schema, Map( "timestampFormat" -> "yyyy/MM/dd HH:mm:ss" )) as "data", col("timestamp") cast "long" as "TM_EXT_KAFKA")
+        .select("data.*", "TM_EXT_KAFKA")
+        .withColumn("TM_EXT_KAFKA", col("TM_EXT_KAFKA") * 1000)
+        .withColumn("TM_SSDS", unix_timestamp * 1000 )
+    } else {
+      reader
+        .load.select(from_json(col("value") cast "string", schema, Map( "timestampFormat" -> "yyyy/MM/dd HH:mm:ss" )) as "data")
+        .select("data.*")
+    }
     
     val processing = new AtomicBoolean(true)
     val dataQueue = new LinkedTransferQueue[DataFrame]()
@@ -123,6 +140,7 @@ object KafkaReader {
           spliceUrl,
           spliceKafkaServers,
           spliceKafkaPartitions,
+          useFlowMarkers,
           dataQueue,
           taskQueue,
           batchRegulation,
@@ -140,6 +158,7 @@ object KafkaReader {
           spliceUrl,
           spliceKafkaServers,
           spliceKafkaPartitions,
+          useFlowMarkers,
           spliceTable,
           values.schema,
           taskQueue,
@@ -157,6 +176,7 @@ object KafkaReader {
 //          spliceUrl,
 //          spliceKafkaServers,
 //          spliceKafkaPartitions,
+//          useFlowMarkers,
 //          spliceTable,
 //          values.schema,
 //          dataQueue,
@@ -168,7 +188,6 @@ object KafkaReader {
     val strQuery = values
       .writeStream
       .option("checkpointLocation",s"/tmp/checkpointLocation-$spliceTable-${java.util.UUID.randomUUID()}")
-//      .option("timestampFormat", "yyyy/MM/dd HH:mm:ss")
 //      .trigger(Trigger.ProcessingTime(2.second))
       .foreachBatch {
         (batchDF: DataFrame, batchId: Long) => try {

--- a/spark2.4/src/main/scala/Loader.scala
+++ b/spark2.4/src/main/scala/Loader.scala
@@ -10,6 +10,7 @@ class Loader(
               spliceUrl: String,
               spliceKafkaServers: String,
               spliceKafkaPartitions: String,
+              useFlowMarkers: Boolean,
               dataQueue: BlockingQueue[DataFrame],
               taskQueue: BlockingDeque[(Seq[RowForKafka], Long, String)],
               batchRegulation: BatchRegulation,
@@ -22,7 +23,7 @@ class Loader(
     "url" -> spliceUrl,
     "KAFKA_SERVERS" -> spliceKafkaServers,
     "KAFKA_TOPIC_PARTITIONS" -> spliceKafkaPartitions,
-    "USE_FLOW_MARKERS" -> "true"
+    "USE_FLOW_MARKERS" -> useFlowMarkers.toString
   ))
   
 //  val s0 = Seq.empty[String]

--- a/spark2.4/src/main/scala/ParallelLoaderInserter.scala
+++ b/spark2.4/src/main/scala/ParallelLoaderInserter.scala
@@ -19,6 +19,7 @@ class ParallelLoaderInserter(
     spliceUrl: String,
     spliceKafkaServers: String,
     spliceKafkaPartitions: String,
+    useFlowMarkers: Boolean,
     spliceTable: String,
     dfSchema: StructType,
     dataQueue: BlockingQueue[DataFrame],
@@ -36,7 +37,7 @@ class ParallelLoaderInserter(
     "url" -> spliceUrl,
     "KAFKA_SERVERS" -> spliceKafkaServers,
     "KAFKA_TOPIC_PARTITIONS" -> spliceKafkaPartitions,
-    "USE_FLOW_MARKERS" -> "true"
+    "USE_FLOW_MARKERS" -> useFlowMarkers.toString
   ))
 
   val batchCount = new AtomicLong()


### PR DESCRIPTION
Input Schema Example:
For the 4th argument to the KafkaReader main function, pass a DDL string like
"ID STRING NOT NULL, LOCATION STRING, TEMPERATURE FLOAT, HUMIDITY FLOAT, TM TIMESTAMP"